### PR TITLE
Update bignumber.js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "resolved": "https://registry.npmjs.org/@parity/abi/-/abi-2.1.1.tgz",
       "integrity": "sha512-AWd1Lnsau8DvEihzoGg3xCSOIHFqf1tsn14wHVCRv7O5BcCI+6Ww/g4iLjdYKGLjtMKtxdQiUblCcIhaZrqmpQ==",
       "requires": {
-        "bignumber.js": "3.0.1",
         "js-sha3": "0.5.5",
         "utf8": "2.1.2"
       }
@@ -1146,9 +1145,9 @@
       }
     },
     "bignumber.js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-3.0.1.tgz",
-      "integrity": "sha1-gHZS0Q453jfp40lyR+3HmLt0b3Y="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
+      "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
     },
     "binary-extensions": {
       "version": "1.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,11 @@
   "requires": true,
   "dependencies": {
     "@parity/abi": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@parity/abi/-/abi-2.1.1.tgz",
-      "integrity": "sha512-AWd1Lnsau8DvEihzoGg3xCSOIHFqf1tsn14wHVCRv7O5BcCI+6Ww/g4iLjdYKGLjtMKtxdQiUblCcIhaZrqmpQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@parity/abi/-/abi-2.1.4.tgz",
+      "integrity": "sha512-4yPqCYXlLhb9jmmAg+0SkA/2Rmf1ZvPzmGF3WBKvgrAjWPAvj5hZYW5rquRqrP3L22KfG+7A9RAw3aZYp45AMQ==",
       "requires": {
+        "bignumber.js": "4.1.0",
         "js-sha3": "0.5.5",
         "utf8": "2.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "sinon-chai": "2.8.0"
   },
   "dependencies": {
-    "@parity/abi": "^2.1.4",
+    "@parity/abi": "~2.1.4",
     "@parity/jsonrpc": "2.1.x",
     "@parity/wordlist": "1.1.x",
     "bignumber.js": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "sinon-chai": "2.8.0"
   },
   "dependencies": {
-    "@parity/abi": "2.1.x",
+    "@parity/abi": "^2.1.4",
     "@parity/jsonrpc": "2.1.x",
     "@parity/wordlist": "1.1.x",
     "bignumber.js": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@parity/abi": "2.1.x",
     "@parity/jsonrpc": "2.1.x",
     "@parity/wordlist": "1.1.x",
-    "bignumber.js": "3.0.1",
+    "bignumber.js": "4.1.0",
     "blockies": "0.0.2",
     "es6-error": "4.0.2",
     "es6-promise": "^4.1.1",


### PR DESCRIPTION
Updating bignumber.js to 4.1.0 on all repos, see https://github.com/parity-js/shared/pull/4#issuecomment-383031582