### PR TITLE
outAccountInfo: Error handling for meta field invalid JSON

### DIFF
--- a/src/format/output.js
+++ b/src/format/output.js
@@ -33,7 +33,11 @@ function outAccountInfo (infos) {
 
       if (info.meta) {
         ret[address].uuid = info.uuid;
-        ret[address].meta = JSON.parse(info.meta);
+        try {
+          ret[address].meta = JSON.parse(info.meta);
+        } catch (e) {
+          console.error(`Couldn't parse meta field of JSON key file ${info.uuid}`);
+        }
       }
 
       return ret;


### PR DESCRIPTION
Should fix https://github.com/parity-js/shell/issues/127
Previously, if a json key file had invalid JSON as value for its `meta` field, the code would throw an error and no accounts would be returned.

Need to update the dependency of `dapp-wallet` to `@parity/api` once this is merged.